### PR TITLE
Adding PowerShell 7.0 and Java 11 to Windows and Linux stack definitions

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -193,6 +193,26 @@
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
+                    },
+                    {
+                        "displayVersion": "11",
+                        "runtimeVersion": "Java|11",
+                        "supportedFunctionsExtensionVersions": [
+                            "~3"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "java"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "Use32BitWorkerProcess": false,
+                            "linuxFxVersion": "Java|11"
+                        },
+                        "isPreview": false,
+                        "isDeprecated": false,
+                        "isHidden": false
                     }
                 ],
                 "frameworks": [],

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -127,6 +127,23 @@
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
+                    },
+                    {
+                        "displayVersion": "11",
+                        "runtimeVersion": "11",
+                        "supportedFunctionsExtensionVersions": [
+                            "~3"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "java"
+                        },
+                        "siteConfigPropertiesDictionary": {},
+                        "isPreview": false,
+                        "isDeprecated": false,
+                        "isHidden": false
                     }
                 ],
                 "frameworks": [],
@@ -143,7 +160,7 @@
                 "dependency": null,
                 "majorVersions": [
                     {
-                        "displayVersion": "6",
+                        "displayVersion": "6.2",
                         "runtimeVersion": "~6",
                         "supportedFunctionsExtensionVersions": [
                             "~2",
@@ -157,6 +174,25 @@
                         },
                         "siteConfigPropertiesDictionary": {
                             "PowerShellVersion": "~6"
+                        },
+                        "isPreview": false,
+                        "isDeprecated": false,
+                        "isHidden": false
+                    },
+                    {
+                        "displayVersion": "7.0",
+                        "runtimeVersion": "~7",
+                        "supportedFunctionsExtensionVersions": [
+                            "~3"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "powershell"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "PowerShellVersion": "~7"
                         },
                         "isPreview": false,
                         "isDeprecated": false,


### PR DESCRIPTION
This PR contains the following:

* Adding Java 11 and PowerShell 7.0 to Windows functions stack
* Adding Java 11 to Linux functions stack.
* Renaming PowerShell 6 to PowerShell 6.2 for consistency. Please note that the current version of PowerShell is 7.0, and the next version will be 7.1 with .Net 5 