### PR TITLE
Move dotnet linuxFxVersion to siteConfig

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -19,11 +19,11 @@
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
-                            "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-                            "linuxFxVersion": "dotnet|3.1"
+                            "FUNCTIONS_WORKER_RUNTIME": "dotnet"
                         },
                         "siteConfigPropertiesDictionary": {
-                            "Use32BitWorkerProcess": false
+                            "Use32BitWorkerProcess": false,
+                            "linuxFxVersion": "dotnet|3.1"
                         },
                         "isPreview": false,
                         "isDeprecated": false,


### PR DESCRIPTION
Unless I'm missing something obvious here, linuxFxVersion always goes on siteConfig, not app settings.