### PR TITLE
Fixes for a few different issues

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -11,11 +11,11 @@
                 "majorVersions": [
                     {
                         "displayVersion": "3.1",
+                        "runtimeVersion": "dotnet|3.1",
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "runtimeVersion": "dotnet|3.1",
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
@@ -24,6 +24,26 @@
                         "siteConfigPropertiesDictionary": {
                             "Use32BitWorkerProcess": false,
                             "linuxFxVersion": "dotnet|3.1"
+                        },
+                        "isPreview": false,
+                        "isDeprecated": false,
+                        "isHidden": false
+                    },
+                    {
+                        "displayVersion": "2.2",
+                        "runtimeVersion": "dotnet|2.2",
+                        "supportedFunctionsExtensionVersions": [
+                            "~2"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "Use32BitWorkerProcess": false,
+                            "linuxFxVersion": "dotnet|2.2"
                         },
                         "isPreview": false,
                         "isDeprecated": false,
@@ -70,7 +90,7 @@
                             "~2",
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
@@ -146,7 +166,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
@@ -178,6 +198,7 @@
                         "displayVersion": "8",
                         "runtimeVersion": "Java|8",
                         "supportedFunctionsExtensionVersions": [
+                            "~2",
                             "~3"
                         ],
                         "isDefault": true,
@@ -198,9 +219,10 @@
                         "displayVersion": "11",
                         "runtimeVersion": "Java|11",
                         "supportedFunctionsExtensionVersions": [
+                            "~2",
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -166,7 +166,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -198,7 +198,6 @@
                         "displayVersion": "8",
                         "runtimeVersion": "Java|8",
                         "supportedFunctionsExtensionVersions": [
-                            "~2",
                             "~3"
                         ],
                         "isDefault": true,
@@ -219,7 +218,6 @@
                         "displayVersion": "11",
                         "runtimeVersion": "Java|11",
                         "supportedFunctionsExtensionVersions": [
-                            "~2",
                             "~3"
                         ],
                         "isDefault": false,

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -21,7 +21,28 @@
                         "appSettingsDictionary": {
                             "FUNCTIONS_WORKER_RUNTIME": "dotnet"
                         },
-                        "siteConfigPropertiesDictionary": {},
+                        "siteConfigPropertiesDictionary": {
+                            "Use32BitWorkerProcess": true
+                        },
+                        "isPreview": false,
+                        "isDeprecated": false,
+                        "isHidden": false
+                    },
+                    {
+                        "displayVersion": "2.2",
+                        "runtimeVersion": "2.2",
+                        "supportedFunctionsExtensionVersions": [
+                            "~2"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "Use32BitWorkerProcess": true
+                        },
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
@@ -53,7 +74,9 @@
                             "FUNCTIONS_WORKER_RUNTIME": "node",
                             "WEBSITE_NODE_DEFAULT_VERSION": "~12"
                         },
-                        "siteConfigPropertiesDictionary": {},
+                        "siteConfigPropertiesDictionary": {
+                            "Use32BitWorkerProcess": true
+                        },
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
@@ -65,14 +88,16 @@
                             "~2",
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
                             "FUNCTIONS_WORKER_RUNTIME": "node",
                             "WEBSITE_NODE_DEFAULT_VERSION": "~10"
                         },
-                        "siteConfigPropertiesDictionary": {},
+                        "siteConfigPropertiesDictionary": {
+                            "Use32BitWorkerProcess": true
+                        },
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
@@ -90,7 +115,9 @@
                             "FUNCTIONS_WORKER_RUNTIME": "node",
                             "WEBSITE_NODE_DEFAULT_VERSION": "~8"
                         },
-                        "siteConfigPropertiesDictionary": {},
+                        "siteConfigPropertiesDictionary": {
+                            "Use32BitWorkerProcess": true
+                        },
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
@@ -123,7 +150,8 @@
                             "FUNCTIONS_WORKER_RUNTIME": "java"
                         },
                         "siteConfigPropertiesDictionary": {
-                            "JavaVersion": "1.8"
+                            "JavaVersion": "1.8",
+                            "Use32BitWorkerProcess": true
                         },
                         "isPreview": false,
                         "isDeprecated": false,
@@ -133,16 +161,18 @@
                         "displayVersion": "11",
                         "runtimeVersion": "11",
                         "supportedFunctionsExtensionVersions": [
+                            "~2",
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
                             "FUNCTIONS_WORKER_RUNTIME": "java"
                         },
                         "siteConfigPropertiesDictionary": {
-                            "JavaVersion": "11"
+                            "JavaVersion": "11",
+                            "Use32BitWorkerProcess": true
                         },
                         "isPreview": false,
                         "isDeprecated": false,
@@ -176,7 +206,8 @@
                             "FUNCTIONS_WORKER_RUNTIME": "powershell"
                         },
                         "siteConfigPropertiesDictionary": {
-                            "PowerShellVersion": "~6"
+                            "PowerShellVersion": "~6",
+                            "Use32BitWorkerProcess": true
                         },
                         "isPreview": false,
                         "isDeprecated": false,
@@ -188,14 +219,15 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
                             "FUNCTIONS_WORKER_RUNTIME": "powershell"
                         },
                         "siteConfigPropertiesDictionary": {
-                            "PowerShellVersion": "~7"
+                            "PowerShellVersion": "~7",
+                            "Use32BitWorkerProcess": true
                         },
                         "isPreview": false,
                         "isDeprecated": false,

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -122,7 +122,9 @@
                         "appSettingsDictionary": {
                             "FUNCTIONS_WORKER_RUNTIME": "java"
                         },
-                        "siteConfigPropertiesDictionary": {},
+                        "siteConfigPropertiesDictionary": {
+                            "JavaVersion": "1.8"
+                        },
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
@@ -139,7 +141,9 @@
                         "appSettingsDictionary": {
                             "FUNCTIONS_WORKER_RUNTIME": "java"
                         },
-                        "siteConfigPropertiesDictionary": {},
+                        "siteConfigPropertiesDictionary": {
+                            "JavaVersion": "11"
+                        },
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -161,7 +161,6 @@
                         "displayVersion": "11",
                         "runtimeVersion": "11",
                         "supportedFunctionsExtensionVersions": [
-                            "~2",
                             "~3"
                         ],
                         "isDefault": false,


### PR DESCRIPTION
JavaVersion is a site config for Windows -- is there a reason it was left off? I noticed it's the same as RuntimeVersion, but it seems useful to explicitly state that it needs to be set in the site configs.