### PR TITLE
Deprecate powershell v6

### DIFF
--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -292,7 +292,7 @@
                             "use32BitWorkerProcess": true
                         },
                         "isPreview": false,
-                        "isDeprecated": false,
+                        "isDeprecated": true,
                         "isHidden": false
                     },
                     {


### PR DESCRIPTION
According to https://github.com/Azure/azure-cli/issues/14649, powershell v6 is approaching end of life and should be deprecated.