### PR TITLE
Fixed powershell 7 to be a default.

### DIFF
--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -301,7 +301,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {


### PR DESCRIPTION
Previously the only default for powershell was deprecated.