### PR TITLE
Fixed node defaults

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -69,7 +69,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -98,7 +98,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {


### PR DESCRIPTION
There should only be one default for v3. This change would mean 14 is the default for v3 and 10 is the default for v2.

I'm assuming this is meaningful because depending on how the "searching for version" algorithm is implemented in the various tools, it could inconsistently pick between 12 and 14 for v3.