### PR TITLE
Add preview hidden python3.9 support

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -206,7 +206,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -199,6 +199,26 @@
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
+                    },
+                    {
+                        "displayVersion": "3.9",
+                        "runtimeVersion": "Python|3.9",
+                        "supportedFunctionsExtensionVersions": [
+                            "~3"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "python"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "use32BitWorkerProcess": false,
+                            "linuxFxVersion": "Python|3.9"
+                        },
+                        "isPreview": true,
+                        "isDeprecated": false,
+                        "isHidden": true
                     }
                 ],
                 "frameworks": [],


### PR DESCRIPTION
The Python 3.9 support will be available in December. We need to enable it for toolings.
@pragnagopa for review