### PR TITLE
Added dotnet isolated support. Added dotnet 5.0 as in preview.

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -2,6 +2,40 @@
     "value": [
         {
             "id": null,
+            "name": "dotnet-isolated",
+            "type": "Microsoft.Web/availableStacks?osTypeSelected=LinuxFunctions",
+            "properties": {
+                "name": "dotnet-isolated",
+                "display": ".NET Core Isolated",
+                "dependency": null,
+                "majorVersions": [
+                    {
+                        "displayVersion": "5.0",
+                        "runtimeVersion": "5.0",
+                        "supportedFunctionsExtensionVersions": [
+                            "~3"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "use32BitWorkerProcess": false,
+                            "linuxFxVersion": "dotnet-isolated|5.0"
+                        },
+                        "isPreview": true,
+                        "isDeprecated": false,
+                        "isHidden": false
+                    }
+                ],
+                "frameworks": [],
+                "isDeprecated": null
+            }
+        },
+        {
+            "id": null,
             "name": "dotnet",
             "type": "Microsoft.Web/availableStacks?osTypeSelected=LinuxFunctions",
             "properties": {

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -2,11 +2,11 @@
     "value": [
         {
             "id": null,
-            "name": "dotnet-isolated",
+            "name": "dotnet",
             "type": "Microsoft.Web/availableStacks?osTypeSelected=LinuxFunctions",
             "properties": {
-                "name": "dotnet-isolated",
-                "display": ".NET Core Isolated",
+                "name": "dotnet",
+                "display": ".NET Core",
                 "dependency": null,
                 "majorVersions": [
                     {
@@ -28,21 +28,7 @@
                         "isPreview": true,
                         "isDeprecated": false,
                         "isHidden": false
-                    }
-                ],
-                "frameworks": [],
-                "isDeprecated": null
-            }
-        },
-        {
-            "id": null,
-            "name": "dotnet",
-            "type": "Microsoft.Web/availableStacks?osTypeSelected=LinuxFunctions",
-            "properties": {
-                "name": "dotnet",
-                "display": ".NET Core",
-                "dependency": null,
-                "majorVersions": [
+                    },
                     {
                         "displayVersion": "3.1",
                         "runtimeVersion": "dotnet|3.1",

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -15,7 +15,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -2,11 +2,11 @@
     "value": [
         {
             "id": null,
-            "name": "dotnet-isolated",
+            "name": "dotnet",
             "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
             "properties": {
-                "name": "dotnet-isolated",
-                "display": ".NET Core Isolated",
+                "name": "dotnet",
+                "display": ".NET Core",
                 "dependency": null,
                 "majorVersions": [
                     {
@@ -15,33 +15,20 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
                             "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
                         },
                         "siteConfigPropertiesDictionary": {
-                            "use32BitWorkerProcess": true
+                            "use32BitWorkerProcess": true,
+                            "netFrameworkVersion": "v5.0"
                         },
                         "isPreview": true,
                         "isDeprecated": false,
                         "isHidden": false
-                    }
-                ],
-                "frameworks": [],
-                "isDeprecated": null
-            }
-        },
-        {
-            "id": null,
-            "name": "dotnet",
-            "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
-            "properties": {
-                "name": "dotnet",
-                "display": ".NET Core",
-                "dependency": null,
-                "majorVersions": [
+                    },
                     {
                         "displayVersion": "3.1",
                         "runtimeVersion": "3.1",

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -2,6 +2,39 @@
     "value": [
         {
             "id": null,
+            "name": "dotnet-isolated",
+            "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
+            "properties": {
+                "name": "dotnet-isolated",
+                "display": ".NET Core Isolated",
+                "dependency": null,
+                "majorVersions": [
+                    {
+                        "displayVersion": "5.0",
+                        "runtimeVersion": "5.0",
+                        "supportedFunctionsExtensionVersions": [
+                            "~3"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "use32BitWorkerProcess": true
+                        },
+                        "isPreview": true,
+                        "isDeprecated": false,
+                        "isHidden": false
+                    }
+                ],
+                "frameworks": [],
+                "isDeprecated": null
+            }
+        },
+        {
+            "id": null,
             "name": "dotnet",
             "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
             "properties": {


### PR DESCRIPTION
Had to make some guesses on the best way to represent this, but wanted to get something out that we can iterate on. Biggest questions for me:

- Should this just be another `majorVersion` for dotnet? I thought it was sufficiently different that it should be separate, but I don't know if the plan is to replace the old dotnet completely.
- Since it was the only `majorVersion` of dotnet isolated, I had to make it both `isPreview` and 'isDefault`. If it moves to be in normal dotnet, it shouldn't be default.
- Guessed on the `display` and `displayVersion` fields