### PR TITLE
Broke dotnet-isolated into its own runtime

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -2,11 +2,11 @@
     "value": [
         {
             "id": null,
-            "name": "dotnet",
+            "name": "dotnet-isolated",
             "type": "Microsoft.Web/availableStacks?osTypeSelected=LinuxFunctions",
             "properties": {
-                "name": "dotnet",
-                "display": ".NET Core",
+                "name": "dotnet-isolated",
+                "display": ".NET Core Isolated",
                 "dependency": null,
                 "majorVersions": [
                     {
@@ -15,7 +15,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
@@ -28,7 +28,21 @@
                         "isPreview": true,
                         "isDeprecated": false,
                         "isHidden": false
-                    },
+                    }
+                ],
+                "frameworks": [],
+                "isDeprecated": null
+            }
+        },
+        {
+            "id": null,
+            "name": "dotnet",
+            "type": "Microsoft.Web/availableStacks?osTypeSelected=LinuxFunctions",
+            "properties": {
+                "name": "dotnet",
+                "display": ".NET Core",
+                "dependency": null,
+                "majorVersions": [
                     {
                         "displayVersion": "3.1",
                         "runtimeVersion": "dotnet|3.1",

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -2,11 +2,11 @@
     "value": [
         {
             "id": null,
-            "name": "dotnet",
+            "name": "dotnet-isolated",
             "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
             "properties": {
-                "name": "dotnet",
-                "display": ".NET Core",
+                "name": "dotnet-isolated",
+                "display": ".NET Core Isolated",
                 "dependency": null,
                 "majorVersions": [
                     {
@@ -15,7 +15,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
@@ -28,7 +28,21 @@
                         "isPreview": true,
                         "isDeprecated": false,
                         "isHidden": false
-                    },
+                    }
+                ],
+                "frameworks": [],
+                "isDeprecated": null
+            }
+        },
+        {
+            "id": null,
+            "name": "dotnet",
+            "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
+            "properties": {
+                "name": "dotnet",
+                "display": ".NET Core",
+                "dependency": null,
+                "majorVersions": [
                     {
                         "displayVersion": "3.1",
                         "runtimeVersion": "3.1",


### PR DESCRIPTION
Per the .Net 5 worker team, I'm moving dotnet-isolated into its own runtime. This matches what's in the CLI right now.