### PR TITLE
Update stacks API with Functions V4 supported runtimes

### DIFF
--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -198,7 +198,8 @@
                         "runtimeVersion": "Python|3.7",
                         "supportedFunctionsExtensionVersions": [
                             "~2",
-                            "~3"
+                            "~3",
+                            "~4"
                         ],
                         "isDefault": true,
                         "minorVersions": [],

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -307,7 +307,7 @@
                         "displayVersion": "8",
                         "runtimeVersion": "Java|8",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3", "~4"
                         ],
                         "isDefault": true,
                         "minorVersions": [],

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -101,7 +101,7 @@
                         "displayVersion": "14",
                         "runtimeVersion": "Node|14",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3", "~4"
                         ],
                         "isDefault": false,
                         "minorVersions": [],

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -361,7 +361,7 @@
                         "displayVersion": "7.0",
                         "runtimeVersion": "PowerShell|7",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3", "~4"
                         ],
                         "isDefault": true,
                         "minorVersions": [],

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -379,6 +379,26 @@
                         "isPreview": true,
                         "isDeprecated": false,
                         "isHidden": true
+                    },
+                    {
+                        "displayVersion": "7.2",
+                        "runtimeVersion": "PowerShell|7.2",
+                        "supportedFunctionsExtensionVersions": [
+                            "~4"
+                        ],
+                        "isDefault": false,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "powershell"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "use32BitWorkerProcess": false,
+                            "linuxFxVersion": "PowerShell|7.2"
+                        },
+                        "isPreview": true,
+                        "isDeprecated": false,
+                        "isHidden": true
                     }
                 ],
                 "frameworks": [],

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -327,7 +327,7 @@
                         "displayVersion": "11",
                         "runtimeVersion": "Java|11",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3", "~4"
                         ],
                         "isDefault": false,
                         "minorVersions": [],

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -240,7 +240,8 @@
                         "displayVersion": "3.9",
                         "runtimeVersion": "Python|3.9",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3",
+                            "~4"
                         ],
                         "isDefault": false,
                         "minorVersions": [],

--- a/LinuxFunctionsStacks.json
+++ b/LinuxFunctionsStacks.json
@@ -219,7 +219,8 @@
                         "displayVersion": "3.8",
                         "runtimeVersion": "Python|3.8",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3",
+                            "~4"
                         ],
                         "isDefault": true,
                         "minorVersions": [],

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -278,7 +278,8 @@
                         "runtimeVersion": "1.8",
                         "supportedFunctionsExtensionVersions": [
                             "~2",
-                            "~3"
+                            "~3",
+                            "~4"
                         ],
                         "isDefault": true,
                         "minorVersions": [],

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -130,7 +130,7 @@
                         "displayVersion": "14",
                         "runtimeVersion": "~14",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3", "~4"
                         ],
                         "isDefault": false,
                         "minorVersions": [],

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -370,6 +370,26 @@
                         "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
+                    },
+                    {
+                        "displayVersion": "7.2",
+                        "runtimeVersion": "7.2",
+                        "supportedFunctionsExtensionVersions": [
+                            "~4"
+                        ],
+                        "isDefault": false,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "powershell"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "powerShellVersion": "7.2",
+                            "use32BitWorkerProcess": true
+                        },
+                        "isPreview": true,
+                        "isDeprecated": false,
+                        "isHidden": false
                     }
                 ],
                 "frameworks": [],

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -299,7 +299,8 @@
                         "displayVersion": "11",
                         "runtimeVersion": "11",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3",
+                            "~4"
                         ],
                         "isDefault": false,
                         "minorVersions": [],

--- a/WindowsFunctionsStacks.json
+++ b/WindowsFunctionsStacks.json
@@ -353,7 +353,7 @@
                         "displayVersion": "7.0",
                         "runtimeVersion": "~7",
                         "supportedFunctionsExtensionVersions": [
-                            "~3"
+                            "~3", "~4"
                         ],
                         "isDefault": true,
                         "minorVersions": [],


### PR DESCRIPTION
Updating stacks API with Functions V4 supported runtimes as defined here: https://github.com/Azure/Azure-Functions/issues/1999

The table below with the V4 column shows the runtimes that are being enabled on this PR. 

| Language  | v1  | v2       | v3            | v4                   |
|-----------|-----|----------|---------------|----------------------|
| Java      | N/A | 8        | 11, 8         | 11, 8                |
| Node.js   | 6   | 10, 8    | 14, 12, 10    | 14              |
| PowerShell| N/A | 6        | 7.0, 6        | 7.2<sup>1</sup>, 7.0            |
| Python    | N/A | 3.7, 3.6 | 3.9<sup>1</sup>, 3.8, 3.7, 3.6 | 3.9<sup>1</sup>, 3.8, 3.7 |

<sup>1</sup> GA support of these versions in Azure Functions is expected by the end of 2021

Please note that **Node 16** and **Python 3.10** are missing from this list.

